### PR TITLE
fix(docs): correct panic message in copied example code

### DIFF
--- a/reactive_graph/src/owner/context.rs
+++ b/reactive_graph/src/owner/context.rs
@@ -237,10 +237,10 @@ pub fn provide_context<T: Send + Sync + 'static>(value: T) {
 ///     Effect::new(move |_| {
 ///         // each use_context clones the value
 ///         let value =
-///             use_context::<String>().expect("could not find i32 in context");
+///             use_context::<String>().expect("could not find String in context");
 ///         assert_eq!(value, "foo");
 ///         let value2 =
-///             use_context::<String>().expect("could not find i32 in context");
+///             use_context::<String>().expect("could not find String in context");
 ///         assert_eq!(value2, "foo");
 ///     });
 /// });
@@ -285,10 +285,10 @@ pub fn use_context<T: Clone + 'static>() -> Option<T> {
 ///     Effect::new(move |_| {
 ///         // each use_context clones the value
 ///         let value =
-///             use_context::<String>().expect("could not find i32 in context");
+///             use_context::<String>().expect("could not find String in context");
 ///         assert_eq!(value, "foo");
 ///         let value2 =
-///             use_context::<String>().expect("could not find i32 in context");
+///             use_context::<String>().expect("could not find String in context");
 ///         assert_eq!(value2, "foo");
 ///     });
 /// });


### PR DESCRIPTION
This short changeset merely fixes a few panic messages of copied–and– adjusted documentation code examples.